### PR TITLE
Изменения на странице исполнения бюджета проекта

### DIFF
--- a/front/pages/_app.tsx
+++ b/front/pages/_app.tsx
@@ -8,6 +8,8 @@ import theme from '../src/theme'
 import createEmotionCache from '../src/createEmotionCache'
 import {LocalizationProvider} from '@mui/x-date-pickers'
 import {AdapterDayjs} from '@mui/x-date-pickers/AdapterDayjs'
+import {ConfigProvider} from 'antd'
+import ruRU from 'antd/locale/ru_RU'
 import 'dayjs/locale/ru'
 import {SWRConfig} from 'swr'
 
@@ -35,7 +37,9 @@ export default function MyApp(props: MyAppProps) {
 					{/* CssBaseline kickstart an elegant, consistent, and simple baseline to build upon. */}
 					<CssBaseline/>
 					<LocalizationProvider dateAdapter={AdapterDayjs} adapterLocale={'ru'}>
-						<Component {...pageProps} />
+						<ConfigProvider locale={ruRU}>
+							<Component {...pageProps} />
+						</ConfigProvider>
 					</LocalizationProvider>
 				</ThemeProvider>
 			</CacheProvider>

--- a/front/src/components/MainLayout/index.tsx
+++ b/front/src/components/MainLayout/index.tsx
@@ -116,7 +116,7 @@ export default function MainLayout({
 					onClick={item => router.push(item.key)}
 				/>
 			</Layout.Header>
-			<Layout>
+			<Layout hasSider>
 				<Layout.Sider width={200} style={{background: colorBgContainer}}>
 					{!!sidebarItems && (
 						<Menu

--- a/front/src/pages/projects/project/budget/clientPayments.tsx
+++ b/front/src/pages/projects/project/budget/clientPayments.tsx
@@ -10,9 +10,16 @@ import {
 	TableRow,
 	TextField,
 } from '@mui/material'
-import {DatePicker} from '@mui/x-date-pickers'
+import {DatePicker} from 'antd'
+import {Dayjs} from 'dayjs'
 import React from 'react'
-import {formStyle, isValidDate, toViewModelNumber, toViewNumber} from './common'
+import {
+	formStyle,
+	getPopupContainer,
+	toViewModelNumber,
+	toViewNumber,
+	toViewStatus,
+} from './common'
 import * as model from './model'
 import styles from './styles.module.css'
 
@@ -35,7 +42,7 @@ function ClientPayment(props: ClientPaymentProps) {
 		})
 	}
 
-	function setPaymentDate(paymentDate: Date | null) {
+	function setPaymentDate(paymentDate: Dayjs | null) {
 		props.setPayment({
 			...props.payment,
 			paymentDate,
@@ -58,10 +65,11 @@ function ClientPayment(props: ClientPaymentProps) {
 			</TableCell>
 			<TableCell>
 				<DatePicker
-					renderInput={props => <TextField {...props}/>}
 					value={props.payment.paymentDate}
 					onChange={setPaymentDate}
 					className={styles.form_control}
+					getPopupContainer={getPopupContainer}
+					status={toViewStatus(props.payment.paymentDate === null)}
 				/>
 			</TableCell>
 			<TableCell>
@@ -78,14 +86,14 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 		needsValidation: boolean,
 		paymentId: number,
 		amount?: number,
-		paymentDate: Date | null,
+		paymentDate: Dayjs | null,
 	}
 
 	function makeNewPayment(paymentId: number): NewPaymentState {
 		return {
 			needsValidation: false,
 			paymentId,
-			paymentDate: new Date(),
+			paymentDate: null,
 		}
 	}
 
@@ -107,7 +115,7 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 		})
 	}
 
-	function setNewPaymentDate(paymentDate: Date | null) {
+	function setNewPaymentDate(paymentDate: Dayjs | null) {
 		setNewPayment({
 			...newPayment,
 			paymentDate,
@@ -115,7 +123,7 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 	}
 
 	function addPayment() {
-		if (newPayment.amount === undefined || !isValidDate(newPayment.paymentDate)) {
+		if (newPayment.amount === undefined || newPayment.paymentDate === null) {
 			setNewPaymentNeedsValidation()
 			return
 		}
@@ -177,10 +185,11 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 						</TableCell>
 						<TableCell>
 							<DatePicker
-								renderInput={props => <TextField {...props}/>}
 								value={newPayment.paymentDate}
 								onChange={setNewPaymentDate}
 								className={styles.form_control}
+								getPopupContainer={getPopupContainer}
+								status={toViewStatus(newPayment.needsValidation && newPayment.paymentDate === null)}
 							/>
 						</TableCell>
 						<TableCell>

--- a/front/src/pages/projects/project/budget/common.ts
+++ b/front/src/pages/projects/project/budget/common.ts
@@ -1,4 +1,5 @@
 import {SxProps} from '@mui/material'
+import {Dayjs} from 'dayjs'
 
 export const pageContainerId = 'projectBudgetPageContainer'
 
@@ -11,15 +12,11 @@ export function getPopupContainer() {
 	return document.getElementById(pageContainerId)!
 }
 
-export function isValidDate(date: Date | null): boolean {
-	return date !== null
-}
-
-export function toApiModelDate(date: Date | null): Date {
-	if (!isValidDate(date)) {
+export function toApiModelDate(date: Dayjs | null): Date {
+	if (date === null) {
 		throw 'invalid date'
 	}
-	return date!
+	return date.toDate()
 }
 
 export function toApiModelNumber(value?: number): number {
@@ -35,4 +32,8 @@ export function toViewModelNumber(value: string): number | undefined {
 
 export function toViewNumber(value?: number): number | '' {
 	return value !== undefined ? value : ''
+}
+
+export function toViewStatus(hasError?: boolean): 'error' | undefined {
+	return hasError ? 'error' : undefined
 }

--- a/front/src/pages/projects/project/budget/common.ts
+++ b/front/src/pages/projects/project/budget/common.ts
@@ -1,8 +1,14 @@
 import {SxProps} from '@mui/material'
 
+export const pageContainerId = 'projectBudgetPageContainer'
+
 export const formStyle: SxProps = {
 	mt: 3,
 	maxWidth: 'fit-content',
+}
+
+export function getPopupContainer() {
+	return document.getElementById(pageContainerId)!
 }
 
 export function isValidDate(date: Date | null): boolean {

--- a/front/src/pages/projects/project/budget/costPayments.tsx
+++ b/front/src/pages/projects/project/budget/costPayments.tsx
@@ -10,16 +10,16 @@ import {
 	TableRow,
 	TextField,
 } from '@mui/material'
-import {DatePicker} from '@mui/x-date-pickers'
-import {Select} from 'antd'
+import {DatePicker, Select} from 'antd'
+import {Dayjs} from 'dayjs'
 import React from 'react'
 import {CostType} from '../../../../../api/costTypes/useCostTypes'
 import {
 	formStyle,
 	getPopupContainer,
-	isValidDate,
 	toViewModelNumber,
 	toViewNumber,
+	toViewStatus,
 } from './common'
 import * as model from './model'
 import styles from './styles.module.css'
@@ -59,7 +59,7 @@ function CostSelect(props: CostSelectProps) {
 			options={props.costs.map(toViewCostType)}
 			optionFilterProp="label"
 			showSearch
-			status={props.error ? 'error' : undefined}
+			status={toViewStatus(props.error)}
 		/>
 	)
 }
@@ -79,7 +79,7 @@ function CostPayment(props: CostPaymentProps) {
 		})
 	}
 
-	function setPaymentDate(paymentDate: Date | null) {
+	function setPaymentDate(paymentDate: Dayjs | null) {
 		props.setPayment({
 			...props.payment,
 			paymentDate,
@@ -109,10 +109,11 @@ function CostPayment(props: CostPaymentProps) {
 			</TableCell>
 			<TableCell>
 				<DatePicker
-					renderInput={props => <TextField {...props}/>}
 					value={props.payment.paymentDate}
 					onChange={setPaymentDate}
 					className={styles.form_control}
+					getPopupContainer={getPopupContainer}
+					status={toViewStatus(props.payment.paymentDate === null)}
 				/>
 			</TableCell>
 			<TableCell>
@@ -130,14 +131,14 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 		paymentId: number,
 		costId?: number,
 		amount?: number,
-		paymentDate: Date | null,
+		paymentDate: Dayjs | null,
 	}
 
 	function makeNewPayment(paymentId: number): NewPaymentState {
 		return {
 			needsValidation: false,
 			paymentId,
-			paymentDate: new Date(),
+			paymentDate: null,
 		}
 	}
 
@@ -166,7 +167,7 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 		})
 	}
 
-	function setNewPaymentDate(paymentDate: Date | null) {
+	function setNewPaymentDate(paymentDate: Dayjs | null) {
 		setNewPayment({
 			...newPayment,
 			paymentDate,
@@ -174,7 +175,7 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 	}
 
 	function addPayment() {
-		if (newPayment.costId === undefined || newPayment.amount === undefined || !isValidDate(newPayment.paymentDate)) {
+		if (newPayment.costId === undefined || newPayment.amount === undefined || newPayment.paymentDate === null) {
 			setNewPaymentNeedsValidation()
 			return
 		}
@@ -246,10 +247,11 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 						</TableCell>
 						<TableCell>
 							<DatePicker
-								renderInput={props => <TextField {...props}/>}
 								value={newPayment.paymentDate}
 								onChange={setNewPaymentDate}
 								className={styles.form_control}
+								getPopupContainer={getPopupContainer}
+								status={toViewStatus(newPayment.needsValidation && newPayment.paymentDate === null)}
 							/>
 						</TableCell>
 						<TableCell>

--- a/front/src/pages/projects/project/budget/costPayments.tsx
+++ b/front/src/pages/projects/project/budget/costPayments.tsx
@@ -1,10 +1,7 @@
 import {AddCircleOutline, Delete} from '@mui/icons-material'
 import {
-	FormControl,
 	IconButton,
-	MenuItem,
 	Paper,
-	Select,
 	Table,
 	TableBody,
 	TableCell,
@@ -14,9 +11,16 @@ import {
 	TextField,
 } from '@mui/material'
 import {DatePicker} from '@mui/x-date-pickers'
+import {Select} from 'antd'
 import React from 'react'
 import {CostType} from '../../../../../api/costTypes/useCostTypes'
-import {formStyle, isValidDate, toViewModelNumber, toViewNumber} from './common'
+import {
+	formStyle,
+	getPopupContainer,
+	isValidDate,
+	toViewModelNumber,
+	toViewNumber,
+} from './common'
 import * as model from './model'
 import styles from './styles.module.css'
 
@@ -27,6 +31,7 @@ interface CostPaymentsTableProps {
 }
 
 interface CostSelectProps {
+	error?: boolean
 	costId?: number
 	setCostId: (costId: number) => void
 	costs: CostType[]
@@ -40,23 +45,22 @@ interface CostPaymentProps {
 }
 
 function CostSelect(props: CostSelectProps) {
+	const toViewCostType = (value: CostType) => ({
+		label: value.name,
+		value: value.id,
+	})
+
 	return (
 		<Select
-			value={props.costId !== undefined ? props.costId : ''}
-			onChange={event =>
-				props.setCostId(Number(event.target.value))
-			}
+			value={props.costId}
+			onChange={props.setCostId}
 			className={styles.form_control}
-		>
-			{props.costs.map(cost => (
-				<MenuItem
-					key={cost.id}
-					value={cost.id}
-				>
-					{cost.name}
-				</MenuItem>
-			))}
-		</Select>
+			getPopupContainer={getPopupContainer}
+			options={props.costs.map(toViewCostType)}
+			optionFilterProp="label"
+			showSearch
+			status={props.error ? 'error' : undefined}
+		/>
 	)
 }
 
@@ -218,18 +222,12 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 				<TableBody>
 					<TableRow>
 						<TableCell>
-							<FormControl
-								error={
-									newPayment.needsValidation
-									&& newPayment.costId === undefined
-								}
-							>
-								<CostSelect
-									costId={newPayment.costId}
-									setCostId={setNewPaymentCostId}
-									costs={props.costs}
-								/>
-							</FormControl>
+							<CostSelect
+								error={newPayment.needsValidation && newPayment.costId === undefined}
+								costId={newPayment.costId}
+								setCostId={setNewPaymentCostId}
+								costs={props.costs}
+							/>
 						</TableCell>
 						<TableCell>
 							<TextField

--- a/front/src/pages/projects/project/budget/index.tsx
+++ b/front/src/pages/projects/project/budget/index.tsx
@@ -6,7 +6,14 @@ import saveProjectBudget from '../../../../../api/saveProjectBudget'
 import useProjectBudget, {ProjectBudget} from '../../../../../api/useProjectBudget'
 import MainLayout from '../../../../components/MainLayout'
 import ClientPaymentsTable from './clientPayments'
-import {formStyle, toApiModelDate, toApiModelNumber, toViewModelNumber, toViewNumber} from './common'
+import {
+	formStyle,
+	pageContainerId,
+	toApiModelDate,
+	toApiModelNumber,
+	toViewModelNumber,
+	toViewNumber,
+} from './common'
 import CostPaymentsTable from './costPayments'
 import * as model from './model'
 import styles from './styles.module.css'
@@ -91,7 +98,11 @@ function Content(props: ContentProps) {
 		<MainLayout
 			projectId={props.projectId}
 		>
-			{budget && <Container maxWidth="lg">
+			{budget && <Container
+				id={pageContainerId}
+				style={{position: 'relative'}}
+				maxWidth="lg"
+			>
 				<Paper sx={formStyle}>
 					<TextField
 						type="number"

--- a/front/src/pages/projects/project/budget/index.tsx
+++ b/front/src/pages/projects/project/budget/index.tsx
@@ -1,5 +1,6 @@
 import {Container, Paper, SxProps, TextField} from '@mui/material'
 import {Button} from 'antd'
+import dayjs from 'dayjs'
 import React from 'react'
 import useCostTypes, {CostType} from '../../../../../api/costTypes/useCostTypes'
 import saveProjectBudget from '../../../../../api/saveProjectBudget'
@@ -25,12 +26,15 @@ const projectCostStyle: SxProps = {
 const mapToProjectBudgetViewModel = (projectBudget: ProjectBudget): model.ProjectBudget => ({
 	projectCost: projectBudget.projectCost,
 	clientPayments: projectBudget.clientPayments.map((payment, index) => ({
-		...payment,
 		paymentId: index,
+		amount: payment.amount,
+		paymentDate: dayjs(payment.paymentDate),
 	})),
 	costPayments: projectBudget.costPayments.map((payment, index) => ({
-		...payment,
 		paymentId: index,
+		costId: payment.costId,
+		amount: payment.amount,
+		paymentDate: dayjs(payment.paymentDate),
 	})),
 })
 

--- a/front/src/pages/projects/project/budget/model.ts
+++ b/front/src/pages/projects/project/budget/model.ts
@@ -1,14 +1,16 @@
+import {Dayjs} from 'dayjs'
+
 export interface ClientPayment {
 	paymentId: number
 	amount?: number
-	paymentDate: Date | null
+	paymentDate: Dayjs | null
 }
 
 export interface CostPayment {
 	paymentId: number
 	costId: number
 	amount?: number
-	paymentDate: Date | null
+	paymentDate: Dayjs | null
 }
 
 export interface ProjectBudget {


### PR DESCRIPTION
Задача пока не решена полностью, но в ветке есть изменения, которые можно и лучше смержить сейчас.
- Исправлена проблема с прыгающей боковой панелью
- Добавлена локализация ant компонентов
- `Select` и `DatePicker` на странице бюджета проекта заменены компонентами ant
- Поле выбора даты обводится красным тогда, когда это нужно, а не когда оно захочет