### PR TITLE
UX-улучшения страницы исполнения бюджета проекта

### DIFF
--- a/front/src/pages/projects/project/budget/clientPayments.tsx
+++ b/front/src/pages/projects/project/budget/clientPayments.tsx
@@ -8,16 +8,13 @@ import {
 	TableContainer,
 	TableHead,
 	TableRow,
-	TextField,
 } from '@mui/material'
-import {DatePicker} from 'antd'
+import {DatePicker, InputNumber} from 'antd'
 import {Dayjs} from 'dayjs'
 import React from 'react'
 import {
 	formStyle,
 	getPopupContainer,
-	toViewModelNumber,
-	toViewNumber,
 	toViewStatus,
 } from './common'
 import * as model from './model'
@@ -35,7 +32,7 @@ interface ClientPaymentProps {
 }
 
 function ClientPayment(props: ClientPaymentProps) {
-	function setAmount(amount?: number) {
+	function setAmount(amount: number | null) {
 		props.setPayment({
 			...props.payment,
 			amount,
@@ -52,15 +49,11 @@ function ClientPayment(props: ClientPaymentProps) {
 	return (
 		<TableRow>
 			<TableCell>
-				<TextField
-					type="number"
-					variant="standard"
-					value={toViewNumber(props.payment.amount)}
-					onChange={event =>
-						setAmount(toViewModelNumber(event.target.value))
-					}
+				<InputNumber
+					value={props.payment.amount}
+					onChange={setAmount}
 					className={styles.form_control}
-					error={props.payment.amount === undefined}
+					status={toViewStatus(props.payment.amount === null)}
 				/>
 			</TableCell>
 			<TableCell>
@@ -85,7 +78,7 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 	interface NewPaymentState {
 		needsValidation: boolean,
 		paymentId: number,
-		amount?: number,
+		amount: number | null,
 		paymentDate: Dayjs | null,
 	}
 
@@ -93,6 +86,7 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 		return {
 			needsValidation: false,
 			paymentId,
+			amount: null,
 			paymentDate: null,
 		}
 	}
@@ -108,7 +102,7 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 		})
 	}
 
-	function setNewPaymentAmount(amount?: number) {
+	function setNewPaymentAmount(amount: number | null) {
 		setNewPayment({
 			...newPayment,
 			amount,
@@ -123,7 +117,7 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 	}
 
 	function addPayment() {
-		if (newPayment.amount === undefined || newPayment.paymentDate === null) {
+		if (newPayment.amount === null || newPayment.paymentDate === null) {
 			setNewPaymentNeedsValidation()
 			return
 		}
@@ -169,18 +163,11 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 				<TableBody>
 					<TableRow>
 						<TableCell>
-							<TextField
-								type="number"
-								variant="standard"
-								value={toViewNumber(newPayment.amount)}
-								onChange={event =>
-									setNewPaymentAmount(toViewModelNumber(event.target.value))
-								}
+							<InputNumber
+								value={newPayment.amount}
+								onChange={setNewPaymentAmount}
 								className={styles.form_control}
-								error={
-									newPayment.needsValidation
-									&& newPayment.amount === undefined
-								}
+								status={toViewStatus(newPayment.needsValidation && newPayment.amount === null)}
 							/>
 						</TableCell>
 						<TableCell>

--- a/front/src/pages/projects/project/budget/clientPayments.tsx
+++ b/front/src/pages/projects/project/budget/clientPayments.tsx
@@ -1,6 +1,5 @@
-import {AddCircleOutline, Delete} from '@mui/icons-material'
+import {PlusCircleOutlined, DeleteFilled} from '@ant-design/icons'
 import {
-	IconButton,
 	Paper,
 	Table,
 	TableBody,
@@ -9,10 +8,11 @@ import {
 	TableHead,
 	TableRow,
 } from '@mui/material'
-import {DatePicker, InputNumber} from 'antd'
+import {Button, DatePicker, InputNumber} from 'antd'
 import {Dayjs} from 'dayjs'
 import React from 'react'
 import {
+	addRowStyle,
 	formStyle,
 	getPopupContainer,
 	toViewStatus,
@@ -66,9 +66,11 @@ function ClientPayment(props: ClientPaymentProps) {
 				/>
 			</TableCell>
 			<TableCell>
-				<IconButton onClick={props.removePayment}>
-					<Delete/>
-				</IconButton>
+				<Button
+					type="link"
+					icon={<DeleteFilled/>}
+					onClick={props.removePayment}
+				/>
 			</TableCell>
 		</TableRow>
 	)
@@ -161,7 +163,7 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 					</TableRow>
 				</TableHead>
 				<TableBody>
-					<TableRow>
+					<TableRow style={addRowStyle}>
 						<TableCell>
 							<InputNumber
 								value={newPayment.amount}
@@ -180,9 +182,11 @@ export default function ClientPaymentsTable(props: ClientPaymentsTableProps) {
 							/>
 						</TableCell>
 						<TableCell>
-							<IconButton onClick={addPayment}>
-								<AddCircleOutline/>
-							</IconButton>
+							<Button
+								type="link"
+								icon={<PlusCircleOutlined/>}
+								onClick={addPayment}
+							/>
 						</TableCell>
 					</TableRow>
 					{props.clientPayments.map(payment => (

--- a/front/src/pages/projects/project/budget/common.ts
+++ b/front/src/pages/projects/project/budget/common.ts
@@ -19,19 +19,11 @@ export function toApiModelDate(date: Dayjs | null): Date {
 	return date.toDate()
 }
 
-export function toApiModelNumber(value?: number): number {
-	if (value === undefined) {
+export function toApiModelNumber(value: number | null): number {
+	if (value === null) {
 		throw 'required field is missing'
 	}
 	return value
-}
-
-export function toViewModelNumber(value: string): number | undefined {
-	return value !== '' ? Number(value) : undefined
-}
-
-export function toViewNumber(value?: number): number | '' {
-	return value !== undefined ? value : ''
 }
 
 export function toViewStatus(hasError?: boolean): 'error' | undefined {

--- a/front/src/pages/projects/project/budget/common.ts
+++ b/front/src/pages/projects/project/budget/common.ts
@@ -1,3 +1,4 @@
+import {blue} from '@ant-design/colors'
 import {SxProps} from '@mui/material'
 import {Dayjs} from 'dayjs'
 
@@ -6,6 +7,10 @@ export const pageContainerId = 'projectBudgetPageContainer'
 export const formStyle: SxProps = {
 	mt: 3,
 	maxWidth: 'fit-content',
+}
+
+export const addRowStyle = {
+	background: blue[0],
 }
 
 export function getPopupContainer() {

--- a/front/src/pages/projects/project/budget/costPayments.tsx
+++ b/front/src/pages/projects/project/budget/costPayments.tsx
@@ -171,7 +171,7 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 	}
 
 	function addPayment() {
-		if (newPayment.costId === undefined || newPayment.amount === undefined || newPayment.paymentDate === null) {
+		if (newPayment.costId === undefined || newPayment.amount === null || newPayment.paymentDate === null) {
 			setNewPaymentNeedsValidation()
 			return
 		}

--- a/front/src/pages/projects/project/budget/costPayments.tsx
+++ b/front/src/pages/projects/project/budget/costPayments.tsx
@@ -8,17 +8,14 @@ import {
 	TableContainer,
 	TableHead,
 	TableRow,
-	TextField,
 } from '@mui/material'
-import {DatePicker, Select} from 'antd'
+import {DatePicker, InputNumber, Select} from 'antd'
 import {Dayjs} from 'dayjs'
 import React from 'react'
 import {CostType} from '../../../../../api/costTypes/useCostTypes'
 import {
 	formStyle,
 	getPopupContainer,
-	toViewModelNumber,
-	toViewNumber,
 	toViewStatus,
 } from './common'
 import * as model from './model'
@@ -72,7 +69,7 @@ function CostPayment(props: CostPaymentProps) {
 		})
 	}
 
-	function setAmount(amount?: number) {
+	function setAmount(amount: number | null) {
 		props.setPayment({
 			...props.payment,
 			amount,
@@ -96,15 +93,11 @@ function CostPayment(props: CostPaymentProps) {
 				/>
 			</TableCell>
 			<TableCell>
-				<TextField
-					type="number"
-					variant="standard"
-					value={toViewNumber(props.payment.amount)}
-					onChange={event =>
-						setAmount(toViewModelNumber(event.target.value))
-					}
+				<InputNumber
+					value={props.payment.amount}
+					onChange={setAmount}
 					className={styles.form_control}
-					error={props.payment.amount === undefined}
+					status={toViewStatus(props.payment.amount === null)}
 				/>
 			</TableCell>
 			<TableCell>
@@ -130,7 +123,7 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 		needsValidation: boolean,
 		paymentId: number,
 		costId?: number,
-		amount?: number,
+		amount: number | null,
 		paymentDate: Dayjs | null,
 	}
 
@@ -138,6 +131,7 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 		return {
 			needsValidation: false,
 			paymentId,
+			amount: null,
 			paymentDate: null,
 		}
 	}
@@ -160,7 +154,7 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 		})
 	}
 
-	function setNewPaymentAmount(amount?: number) {
+	function setNewPaymentAmount(amount: number | null) {
 		setNewPayment({
 			...newPayment,
 			amount,
@@ -231,18 +225,11 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 							/>
 						</TableCell>
 						<TableCell>
-							<TextField
-								type="number"
-								variant="standard"
-								value={toViewNumber(newPayment.amount)}
-								onChange={event =>
-									setNewPaymentAmount(toViewModelNumber(event.target.value))
-								}
+							<InputNumber
+								value={newPayment.amount}
+								onChange={setNewPaymentAmount}
 								className={styles.form_control}
-								error={
-									newPayment.needsValidation
-									&& newPayment.amount === undefined
-								}
+								status={toViewStatus(newPayment.needsValidation && newPayment.amount === null)}
 							/>
 						</TableCell>
 						<TableCell>

--- a/front/src/pages/projects/project/budget/costPayments.tsx
+++ b/front/src/pages/projects/project/budget/costPayments.tsx
@@ -1,6 +1,5 @@
-import {AddCircleOutline, Delete} from '@mui/icons-material'
+import {PlusCircleOutlined, DeleteFilled} from '@ant-design/icons'
 import {
-	IconButton,
 	Paper,
 	Table,
 	TableBody,
@@ -9,11 +8,12 @@ import {
 	TableHead,
 	TableRow,
 } from '@mui/material'
-import {DatePicker, InputNumber, Select} from 'antd'
+import {Button, DatePicker, InputNumber, Select} from 'antd'
 import {Dayjs} from 'dayjs'
 import React from 'react'
 import {CostType} from '../../../../../api/costTypes/useCostTypes'
 import {
+	addRowStyle,
 	formStyle,
 	getPopupContainer,
 	toViewStatus,
@@ -110,9 +110,11 @@ function CostPayment(props: CostPaymentProps) {
 				/>
 			</TableCell>
 			<TableCell>
-				<IconButton onClick={props.removePayment}>
-					<Delete/>
-				</IconButton>
+				<Button
+					type="link"
+					icon={<DeleteFilled/>}
+					onClick={props.removePayment}
+				/>
 			</TableCell>
 		</TableRow>
 	)
@@ -215,7 +217,7 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 					</TableRow>
 				</TableHead>
 				<TableBody>
-					<TableRow>
+					<TableRow style={addRowStyle}>
 						<TableCell>
 							<CostSelect
 								error={newPayment.needsValidation && newPayment.costId === undefined}
@@ -242,9 +244,11 @@ export default function CostPaymentsTable(props: CostPaymentsTableProps) {
 							/>
 						</TableCell>
 						<TableCell>
-							<IconButton onClick={addPayment}>
-								<AddCircleOutline/>
-							</IconButton>
+							<Button
+								type="link"
+								icon={<PlusCircleOutlined/>}
+								onClick={addPayment}
+							/>
 						</TableCell>
 					</TableRow>
 					{props.costPayments.map(payment => (

--- a/front/src/pages/projects/project/budget/index.tsx
+++ b/front/src/pages/projects/project/budget/index.tsx
@@ -1,5 +1,5 @@
-import {Container, Paper, SxProps, TextField} from '@mui/material'
-import {Button} from 'antd'
+import {Container, Paper, SxProps} from '@mui/material'
+import {Button, Form, InputNumber} from 'antd'
 import dayjs from 'dayjs'
 import React from 'react'
 import useCostTypes, {CostType} from '../../../../../api/costTypes/useCostTypes'
@@ -12,15 +12,15 @@ import {
 	pageContainerId,
 	toApiModelDate,
 	toApiModelNumber,
-	toViewModelNumber,
-	toViewNumber,
+	toViewStatus,
 } from './common'
 import CostPaymentsTable from './costPayments'
 import * as model from './model'
 import styles from './styles.module.css'
 
 const projectCostStyle: SxProps = {
-	m: 2,
+	...formStyle,
+	p: 2,
 }
 
 const mapToProjectBudgetViewModel = (projectBudget: ProjectBudget): model.ProjectBudget => ({
@@ -77,7 +77,7 @@ function Content(props: ContentProps) {
 		await mutate(apiProjectBudget)
 	}
 
-	function setProjectCost(projectCost?: number) {
+	function setProjectCost(projectCost: number | null) {
 		setBudget({
 			...budget!,
 			projectCost,
@@ -107,19 +107,20 @@ function Content(props: ContentProps) {
 				style={{position: 'relative'}}
 				maxWidth="lg"
 			>
-				<Paper sx={formStyle}>
-					<TextField
-						type="number"
-						variant="standard"
-						label="Цена для клиента"
-						value={toViewNumber(budget.projectCost)}
-						onChange={event =>
-							setProjectCost(toViewModelNumber(event.target.value))
-						}
-						sx={projectCostStyle}
-						className={styles.form_control}
-						error={budget.projectCost === undefined}
-					/>
+				<Paper sx={projectCostStyle}>
+					<Form layout="vertical">
+						<Form.Item
+							label="Цена для клиента"
+							style={{margin: 0}}
+						>
+							<InputNumber
+								value={budget.projectCost}
+								onChange={setProjectCost}
+								className={styles.form_control}
+								status={toViewStatus(budget.projectCost === null)}
+							/>
+						</Form.Item>
+					</Form>
 				</Paper>
 				<ClientPaymentsTable
 					clientPayments={budget.clientPayments}

--- a/front/src/pages/projects/project/budget/index.tsx
+++ b/front/src/pages/projects/project/budget/index.tsx
@@ -1,5 +1,5 @@
 import {Container, Paper, SxProps} from '@mui/material'
-import {Button, Form, InputNumber} from 'antd'
+import {Button, Form, InputNumber, message} from 'antd'
 import dayjs from 'dayjs'
 import React from 'react'
 import useCostTypes, {CostType} from '../../../../../api/costTypes/useCostTypes'
@@ -66,15 +66,15 @@ function Content(props: ContentProps) {
 	}
 
 	async function updateProjectBudget() {
-		let apiProjectBudget
 		try {
-			apiProjectBudget = mapToApiProjectBudget(budget!, props.projectId)
+			let apiProjectBudget = mapToApiProjectBudget(budget!, props.projectId)
+			await saveProjectBudget(apiProjectBudget)
+			mutate(apiProjectBudget)
+			message.success('Изменения успешно сохранены')
 		} catch (err) {
-			console.log(err)
-			return
+			console.error(err)
+			message.error('Не удалось сохранить изменения')
 		}
-		await saveProjectBudget(apiProjectBudget)
-		await mutate(apiProjectBudget)
 	}
 
 	function setProjectCost(projectCost: number | null) {

--- a/front/src/pages/projects/project/budget/index.tsx
+++ b/front/src/pages/projects/project/budget/index.tsx
@@ -23,6 +23,22 @@ const projectCostStyle: SxProps = {
 	p: 2,
 }
 
+function isValidProjectBudget(projectBudget: model.ProjectBudget) {
+	function isValidClientPayment(payment: model.ClientPayment) {
+		return payment.amount !== null && payment.paymentDate !== null
+	}
+
+	function isValidCostPayment(payment: model.CostPayment) {
+		return payment.amount !== null && payment.paymentDate !== null
+	}
+
+	return (
+		projectBudget.projectCost !== null
+		&& projectBudget.clientPayments.every(isValidClientPayment)
+		&& projectBudget.costPayments.every(isValidCostPayment)
+	)
+}
+
 const mapToProjectBudgetViewModel = (projectBudget: ProjectBudget): model.ProjectBudget => ({
 	projectCost: projectBudget.projectCost,
 	clientPayments: projectBudget.clientPayments.map((payment, index) => ({
@@ -36,6 +52,7 @@ const mapToProjectBudgetViewModel = (projectBudget: ProjectBudget): model.Projec
 		amount: payment.amount,
 		paymentDate: dayjs(payment.paymentDate),
 	})),
+	hasChangesInModel: false,
 })
 
 const mapToApiProjectBudget = (projectBudget: model.ProjectBudget, projectId: number): ProjectBudget => ({
@@ -70,6 +87,10 @@ function Content(props: ContentProps) {
 			let apiProjectBudget = mapToApiProjectBudget(budget!, props.projectId)
 			await saveProjectBudget(apiProjectBudget)
 			mutate(apiProjectBudget)
+			setBudget({
+				...budget!,
+				hasChangesInModel: false,
+			})
 			message.success('Изменения успешно сохранены')
 		} catch (err) {
 			console.error(err)
@@ -81,6 +102,7 @@ function Content(props: ContentProps) {
 		setBudget({
 			...budget!,
 			projectCost,
+			hasChangesInModel: true,
 		})
 	}
 
@@ -88,6 +110,7 @@ function Content(props: ContentProps) {
 		setBudget({
 			...budget!,
 			clientPayments,
+			hasChangesInModel: true,
 		})
 	}
 
@@ -95,6 +118,7 @@ function Content(props: ContentProps) {
 		setBudget({
 			...budget!,
 			costPayments,
+			hasChangesInModel: true,
 		})
 	}
 
@@ -135,6 +159,7 @@ function Content(props: ContentProps) {
 					type="primary"
 					onClick={updateProjectBudget}
 					style={{margin: '16px 0'}}
+					disabled={!budget.hasChangesInModel || !isValidProjectBudget(budget)}
 				>
                     Сохранить
 				</Button>

--- a/front/src/pages/projects/project/budget/model.ts
+++ b/front/src/pages/projects/project/budget/model.ts
@@ -17,4 +17,5 @@ export interface ProjectBudget {
 	projectCost: number | null
 	clientPayments: ClientPayment[]
 	costPayments: CostPayment[]
+	hasChangesInModel: boolean
 }

--- a/front/src/pages/projects/project/budget/model.ts
+++ b/front/src/pages/projects/project/budget/model.ts
@@ -2,19 +2,19 @@ import {Dayjs} from 'dayjs'
 
 export interface ClientPayment {
 	paymentId: number
-	amount?: number
+	amount: number | null
 	paymentDate: Dayjs | null
 }
 
 export interface CostPayment {
 	paymentId: number
 	costId: number
-	amount?: number
+	amount: number | null
 	paymentDate: Dayjs | null
 }
 
 export interface ProjectBudget {
-	projectCost?: number
+	projectCost: number | null
 	clientPayments: ClientPayment[]
 	costPayments: CostPayment[]
 }

--- a/front/src/pages/projects/project/budget/styles.module.css
+++ b/front/src/pages/projects/project/budget/styles.module.css
@@ -3,5 +3,5 @@
 }
 
 .form_control {
-    width: 300px;
+    width: 250px;
 }


### PR DESCRIPTION
- Поля ввода чисел на странице бюджета проекта заменены компонентами ant
- Материальные иконки заменены иконками ant
- Добавлено отображение сообщения о результате операции
- Реализовано отключение кнопки сохранения при отсутствии изменений/наличии незаполненных полей

Также была идея реализовать запрос подтверждения перехода со страницы при наличии несохранённых изменений, но качественная реализация бы потребовала внести значительные изменения в `src/components/MainLayout` и `layout/useAuthenticatedSWR`, поэтому оставил всё как есть